### PR TITLE
Use Java 8 when installing Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ jenkins_docker_container_name: jenkins
 jenkins_docker_expose_port: true
 ```
 
+Debian-Specific Role Variables
+------------------------------
+
+```yml
+# Packages which are to be installed on the jenkins instance
+jenkins_apt_packages:
+  - openjdk-8-jdk
+
+# Java version to use. Note that JDK 8 is required for Jenkins
+# 2.54 or greater.
+jenkins_java_version: "java-1.8.0-openjdk-amd64"
+```
+
 Example Playbook
 ----------------
 

--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Include Debian-specific variables
+  include_vars: "debian.yml"
+
 - name: Create Jenkins group
   group:
     name: "{{ jenkins_config_group }}"
@@ -39,13 +42,12 @@
     group: root
     mode: 0644
 
-- name: Install OpenJDK 7
-  apt:
-    name: openjdk-7-jdk
-    update_cache: yes
+- name: Install apt packages
+  action: apt name={{ item }} state=present
+  with_items: "{{ jenkins_apt_packages }}"
 
-- name: Update java alternatives
-  shell: /usr/sbin/update-java-alternatives -s java-1.7.0-openjdk-amd64
+- name: Set default Java version
+  shell: /usr/sbin/update-java-alternatives -s "{{ jenkins_java_version }}"
   ignore_errors: yes
 
 - name: Add Jenkins key

--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -10,6 +10,7 @@
     name: "{{ jenkins_config_owner }}"
     group: "{{ jenkins_config_group }}"
     home: "{{ jenkins_home }}"
+    shell: "/bin/false"
     state: present
 
 - name: Install apt PPA dependencies

--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -9,15 +9,8 @@
   user:
     name: "{{ jenkins_config_owner }}"
     group: "{{ jenkins_config_group }}"
+    home: "{{ jenkins_home }}"
     state: present
-
-- name: Ensure jenkins home dir is created
-  file:
-    path: "{{ jenkins_home }}"
-    mode: 0777
-    owner: "{{ jenkins_config_owner }}"
-    group: "{{ jenkins_config_group }}"
-    state: directory
 
 - name: Install apt PPA dependencies
   apt:

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,6 @@
+---
+
+jenkins_apt_packages:
+  - openjdk-8-jdk
+
+jenkins_java_version: "java-1.8.0-openjdk-amd64"


### PR DESCRIPTION
As of Jenkins 2.54, Java 8 is required, and using a Java 7 runtime may result in a non-functional Jenkins installation.

This PR also contains some small fixes regarding the home directory creation and shell of the Jenkins user.