### PR TITLE
Use jenkins_version, jenkins_port variables when installing via apt

### DIFF
--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -62,7 +62,8 @@
 
 - name: Install Jenkins binary package
   apt:
-    name: jenkins
+    name: "jenkins={{ jenkins_version }}"
+    force: yes
     update_cache: yes
 
 - name: Set JENKINS_HOME

--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -72,6 +72,12 @@
     line: "JENKINS_HOME={{ jenkins_home }}"
     regexp: '^JENKINS_HOME='
 
+- name: Set Jenkins port
+  lineinfile:
+    dest: /etc/default/jenkins
+    regexp: '^HTTP_PORT='
+    line: "HTTP_PORT={{ jenkins_port }}"
+
 - name: Set Jenkins command line options
   lineinfile:
     dest: /etc/default/jenkins


### PR DESCRIPTION
Note: The 'force' option is necessary to allow for easily downgrading the Jenkins version.