### PR TITLE
Configure Jenkins location and admin email

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ jenkins_version: "2.32.3" # The exact version of jenkins to deploy
 jenkins_url: "http://127.0.0.1" # The url that Jenkins will be accessible on
 jenkins_port: "8080" # The port that Jenkins will listen on
 jenkins_home: /data/jenkins # The directory on the server where the Jenkins configs will live
+jenkins_admin: "admin@example.com" # The admininstrator email address for the Jenkins server
 
 # If you need to override any java options then do that here.
 jenkins_java_opts: "-Djenkins.install.runSetupWizard=false"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ jenkins_version: "2.32.3" # The exact version of jenkins to deploy
 jenkins_url: "http://127.0.0.1" # The url that Jenkins will be accessible on
 jenkins_port: "8080" # The port that Jenkins will listen on
 jenkins_home: /data/jenkins # The directory on the server where the Jenkins configs will live
+jenkins_admin: "admin@example.com" # The admininstrator email address for the Jenkins server
 
 # If you need to override any java options then do that here.
 jenkins_java_opts: "-Djenkins.install.runSetupWizard=false"

--- a/files/jenkins.model.JenkinsLocationConfiguration.xml.j2
+++ b/files/jenkins.model.JenkinsLocationConfiguration.xml.j2
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<jenkins.model.JenkinsLocationConfiguration>
+  <adminAddress>{{ jenkins_admin }}</adminAddress>
+  <jenkinsUrl>{{ jenkins_url }}:{{ jenkins_port }}</jenkinsUrl>
+</jenkins.model.JenkinsLocationConfiguration>

--- a/tasks/configure-jenkins.yml
+++ b/tasks/configure-jenkins.yml
@@ -8,6 +8,14 @@
     owner: "{{ jenkins_config_owner }}"
     group: "{{ jenkins_config_group }}"
 
+- name: Configure Jenkins location
+  template:
+    src: files/jenkins.model.JenkinsLocationConfiguration.xml.j2
+    dest: "{{ jenkins_home }}/jenkins.model.JenkinsLocationConfiguration.xml"
+    mode: 0644
+    owner: "{{ jenkins_config_owner }}"
+    group: "{{ jenkins_config_group }}"
+
 - name: Create intermediate dirs for custom files
   file:
     path: "{{ jenkins_home }}/{{ item.dest | dirname }}"


### PR DESCRIPTION
This commit creates jenkins.model.JenkinsLocationConfiguration.xml,
which is automatically generated by Jenkins but only after one
manually saves the system configuration. Until this file is generated,
several Jenkins-related environment variables use
"http://unconfigured-jenkins-location" as the server URL.

This change also introduces the jenkins_admin variable for the
administrator's email address, since that is contained in the same XML
file.