### PR TITLE
Add jenkins_docker_image variable and update its name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Role Variables
 --------------
 
 ```yml
-jenkins_version: "2.32.3" # The exact version of jenkins to deploy
+jenkins_version: "2.73.1" # The exact version of jenkins to deploy
+jenkins_docker_image: "jenkins/jenkins" # The docker hub image name
+
 jenkins_url: "http://127.0.0.1" # The url that Jenkins will be accessible on
 jenkins_port: "8080" # The port that Jenkins will listen on
 jenkins_home: /data/jenkins # The directory on the server where the Jenkins configs will live

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 
-jenkins_version: "2.32.3" # The exact version of jenkins to deploy
+jenkins_version: "2.73.1" # The exact version of jenkins to deploy
+jenkins_docker_image: "jenkins/jenkins" # The docker hub image name
+
 jenkins_url: "http://127.0.0.1" # The url that Jenkins will be accessible on
 jenkins_port: "8080" # The port that Jenkins will listen on
 jenkins_home: /data/jenkins # The directory on the server where the Jenkins configs will live

--- a/tasks/docker/install.yml
+++ b/tasks/docker/install.yml
@@ -11,7 +11,7 @@
 - name: Container is running (with ingress port)
   docker_container:
     name: "{{ jenkins_docker_container_name }}"
-    image: "jenkins:{{ jenkins_version }}"
+    image: "{{ jenkins_docker_image }}:{{ jenkins_version }}"
     published_ports:
       - "{{ jenkins_port }}:8080"
     volumes:
@@ -24,7 +24,7 @@
 - name: Container is running (without ingress port)
   docker_container:
     name: "{{ jenkins_docker_container_name }}"
-    image: "jenkins:{{ jenkins_version }}"
+    image: "{{ jenkins_docker_image }}:{{ jenkins_version }}"
     expose: "8080"
     volumes:
       - "{{ jenkins_home }}:/var/jenkins_home"


### PR DESCRIPTION
Jenkins deprecated their 'jenkins' image in favour or 'jenkins/jenkins' image:
https://hub.docker.com/_/jenkins/

This updates to the new jenkins image, as well as to latest lts version.