### PR TITLE
Fixes jenkins docker image references

### DIFF
--- a/tasks/docker/restart.yml
+++ b/tasks/docker/restart.yml
@@ -3,7 +3,7 @@
 - name: Container is running
   docker_container:
     name: "{{ jenkins_docker_container_name }}"
-    image: "jenkins:{{ jenkins_version }}"
+    image: "{{ jenkins_docker_image }}:{{ jenkins_version }}"
     published_ports: "{{ jenkins_port }}:8080"
     volumes:
       - "{{ jenkins_home }}:/var/jenkins_home"

--- a/tasks/docker/stop.yml
+++ b/tasks/docker/stop.yml
@@ -3,7 +3,7 @@
 - name: Container is stopped
   docker_container:
     name: "{{ jenkins_docker_container_name }}"
-    image: "jenkins:{{ jenkins_version }}"
+    image: "{{ jenkins_docker_image }}:{{ jenkins_version }}"
     published_ports: "{{ jenkins_port }}:8080"
     volumes:
       - "{{ jenkins_home }}:/var/jenkins_home"


### PR DESCRIPTION
A previous commit [1] added the jenkins_docker_image variable,
but it is not used in all the docker tasks, which means that
reinstalling the role would fail.

Fixes the jenkins docker image references in the stop and restart
docker tasks.

[1] ecab7ed9aeb474f116499e2bead9ce7aec40317c