### PR TITLE
Remove broken reference to debian.yml

### DIFF
--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -1,8 +1,4 @@
 ---
-
-- name: Include Debian-specific variables
-  include_vars: "debian.yml"
-
 - name: Create Jenkins group
   group:
     name: "{{ jenkins_config_group }}"


### PR DESCRIPTION
The `debian.yml` vars file was removed in https://github.com/emmetog/ansible-jenkins/commit/41ba43070e657b38916b725b44397451a46493f6, so this reference should also be removed, since otherwise this will cause Ansible to fail with an error.