### PR TITLE
Use uri task to wait for Jenkins to start up

### DIFF
--- a/tasks/apt/restart.yml
+++ b/tasks/apt/restart.yml
@@ -4,5 +4,3 @@
   service:
     name: jenkins
     state: restarted
-
-- pause: seconds=15

--- a/tasks/docker/restart.yml
+++ b/tasks/docker/restart.yml
@@ -10,5 +10,3 @@
     env:
       JAVA_OPTS: "{{ jenkins_java_opts }}"
     restart: yes
-
-- pause: seconds=15

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
 - include: "configure-jenkins.yml"
 
 - include: "{{ jenkins_install_via }}/restart.yml"
+- include: "wait-for-start.yml"
 - include: "configure-plugins.yml"
 
 - include: "configure-jobs.yml"

--- a/tasks/wait-for-start.yml
+++ b/tasks/wait-for-start.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Wait for Jenkins to start
+  uri:
+    url: "{{ jenkins_url }}:{{ jenkins_port }}"
+  delegate_to: localhost
+  register: jenkins_home_content
+  # Jenkins will return 503 (service unavailable) on the home page while
+  # starting (the "Please wait while Jenkins is getting ready to work" page)
+  until: jenkins_home_content.status == 200
+  retries: 30
+  delay: 5


### PR DESCRIPTION
Using the pause task is a bit problematic, since it can either waste a
lot of time on fast systems or time out on really slow ones. This
commit uses the uri task to fetch the Jenkins homepage until it
returns status code 200. Jenkins will return 503 (service unavailable)
while it is loading.