### PR TITLE
Use "become: false" for uri task

### DIFF
--- a/tasks/wait-for-start.yml
+++ b/tasks/wait-for-start.yml
@@ -4,6 +4,7 @@
   uri:
     url: "{{ jenkins_url }}:{{ jenkins_port }}"
   delegate_to: localhost
+  become: false
   register: jenkins_home_content
   # Jenkins will return 503 (service unavailable) on the home page while
   # starting (the "Please wait while Jenkins is getting ready to work" page)


### PR DESCRIPTION
This is necessary because in certain situations (specifically, when
using the apt installation method), it is necessary to use 'become'
when applying this role. However, that does not mix well with
delegate_to: localhost, which should presumably never require
superuser privileges to execute on the machine running Ansible.