### PR TITLE
Put Jenkins in quiet mode when installing plugins/jobs

### DIFF
--- a/tasks/cancel-quiet-mode.yml
+++ b/tasks/cancel-quiet-mode.yml
@@ -1,0 +1,17 @@
+---
+- name: Get token for Jenkins API
+  uri:
+    url: '{{ jenkins_url }}:{{ jenkins_port }}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'
+    return_content: yes
+    status_code: 200,404
+  register: jenkins_token
+
+- name: Cancel quiet mode
+  uri:
+    url: "{{ jenkins_url }}:{{ jenkins_port }}/cancelQuietDown"
+    method: POST
+    headers:
+      Content-Type: "text/xml"
+      Jenkins-Crumb: "{{ jenkins_token.content.split(':')[1] | default('noCrumb') }}"
+    status_code: 200,302
+  when: jenkins_token.status == 200

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,9 @@
 
 - include: "{{ jenkins_install_via }}/restart.yml"
 - include: "wait-for-start.yml"
+- include: "set-quiet-mode.yml"
 - include: "configure-plugins.yml"
 
 - include: "configure-jobs.yml"
+- include: "cancel-quiet-mode.yml"
 - include: "{{ jenkins_after_config_jobs_file | default('empty.yml') }}"

--- a/tasks/set-quiet-mode.yml
+++ b/tasks/set-quiet-mode.yml
@@ -1,0 +1,17 @@
+---
+- name: Get token for Jenkins API
+  uri:
+    url: '{{ jenkins_url }}:{{ jenkins_port }}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'
+    return_content: yes
+    status_code: 200,404
+  register: jenkins_token
+
+- name: Set quiet mode
+  uri:
+    url: "{{ jenkins_url }}:{{ jenkins_port }}/quietDown"
+    method: POST
+    headers:
+      Content-Type: "text/xml"
+      Jenkins-Crumb: "{{ jenkins_token.content.split(':')[1] | default('noCrumb') }}"
+    status_code: 200,302
+  when: jenkins_token.status == 200


### PR DESCRIPTION
Jenkins needs to be up and running in order to install plugins, but
it's a bad idea to accept new builds, since any number of things can
go wrong during this time.

Accepting builds while copying job configuration files is equally
dangerous. This could be avoided by shutting down Jenkins, as we do
when configuring Jenkins core files.  However, as long as we're
already in quiet mode for the plugin installation we can just keep
Jenkins running and avoid a potentially long service restart.

---

ping @emmetog, thanks!