### PR TITLE
Don't restart at end of apt install play

### DIFF
--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -79,10 +79,3 @@
     dest: /etc/default/jenkins
     regexp: '^JAVA_ARGS='
     line: "JAVA_ARGS=\"{{ jenkins_java_opts }}\""
-
-- name: Jenkins is running
-  service:
-    name: jenkins
-    state: restarted
-
-- pause: seconds=15


### PR DESCRIPTION
It is not necessary to restart Jenkins here, since main.yml will stop
Jenkins as the very next task.

---

ping @emmetog 