### PR TITLE
Retry fetching Jenkins API token task

### DIFF
--- a/tasks/get-crumb.yml
+++ b/tasks/get-crumb.yml
@@ -5,6 +5,9 @@
     return_content: yes
     status_code: 200,404
   register: jenkins_token_result
+  until: jenkins_token_result.status == 200 or jenkins_token_result.status == 404
+  retries: 5
+  delay: 1
 
 - set_fact:
     jenkins_token: "{{ jenkins_token_result }}"


### PR DESCRIPTION
When deploying a fresh Jenkins master, reloading can sometimes take a
few seconds, during which time Jenkins will return 503 (service
unavailable). This change makes the role a bit more tolerant of such
conditions by allowing up to 5 retries for Jenkins to reload.

---

ping @emmetog 