### PR TITLE
Ensure correct ownership of JENKINS_HOME directory

### DIFF
--- a/tasks/configure-jenkins.yml
+++ b/tasks/configure-jenkins.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Ensure correct ownership of JENKINS_HOME directory
+  file:
+    path: "{{ jenkins_home }}"
+    owner: "{{ jenkins_config_owner }}"
+    group: "{{ jenkins_config_group }}"
+    mode: 0755
+    state: directory
+
 - name: Configuration file is up to date (config.xml)
   template:
     src: "{{ jenkins_source_config_xml }}"


### PR DESCRIPTION
For the native installation types (apt, yum), JENKINS_HOME is created
with the Jenkins user on when the package is installed. In either
case, it is quite likely that root will own this directory. Therefore,
we should ensure that the correct Jenkins user owns this directory.

In the case of the user module, the home directory created by Ansible
is always owned by root:root, which is a known bug in Ansible:

https://github.com/ansible/ansible/issues/24862

As luck would have it, the "Create intermediate dirs for custom files"
task was accidentally doing this work for us. However, if the user did
not set any items for the jenkins_custom_files var, then this would
cause Jenkins to fail at startup.

---

ping @emmetog 