### PR TITLE
Check response success flag before status check

### DIFF
--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -8,6 +8,6 @@
   register: jenkins_home_content
   # Jenkins will return 503 (service unavailable) on the home page while
   # starting (the "Please wait while Jenkins is getting ready to work" page)
-  until: jenkins_home_content.status == 200
+  until: jenkins_home_content is success and jenkins_home_content.status == 200
   retries: 30
   delay: 5


### PR DESCRIPTION
If the uri module fails (on account of the host being down etc) then
the jenkins_home_content dict will not yet be populated and Ansible
will fail with a "'dict object' has no attribute 'status'" error.
Thus, we need to check that the request was successful, regardless of
the HTTP status, before examining the status.

---

ping @emmetog, thanks!