### PR TITLE
Introduce variable for plugin installation timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,11 @@ jenkins_plugins:
   - template-project
   - ec2
 
+# How long to wait for installing plugins, in seconds. If you are seeing failures in the
+# "Wait for plugins to finish installing" task with an error message like "Timeout when
+# waiting for file <plugin_name.jpi>", you may want to increase this value.
+jenkins_plugin_timeout: 300
+
 # List of sources of custom jenkins plugins to install
 jenkins_custom_plugins: []
 

--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -43,4 +43,5 @@
 - name: Wait for plugins to finish installing
   wait_for:
     path: "{{ jenkins_home }}/plugins/{{ item }}.jpi"
+    timeout: "{{ jenkins_plugin_timeout }}"
   with_items: "{{ jenkins_plugins }}"


### PR DESCRIPTION
Some plugins, such as Blue Ocean, have large dependency trees and can
take some time to install. This commit introduces a new variable,
which can be increased for users who are installing a large amount of
plugins, plugins with deep dependency trees, or perhaps are using a
Jenkins master with meager I/O capabilities.

The default value is 300, which is the same as the default value for
the timeout option of the wait_for module.

---

ping @emmetog 