### PR TITLE
Use Ansible's jenkins_plugin module

### DIFF
--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -5,30 +5,15 @@
 # scheduled.
 - include_tasks: "start.yml"
 - include_tasks: "set-quiet-mode.yml"
-- include_tasks: "get-crumb.yml"
 
-- name: Install plugins if crumb is enabled
-  uri:
-    url: "{{ jenkins_url }}:{{ jenkins_port }}/pluginManager/installNecessaryPlugins"
-    method: POST
-    headers:
-      Content-Type: "text/xml"
-      Jenkins-Crumb: "{{ jenkins_token.content.split(':')[1] | default('noCrumb') }}"
-    body: "<jenkins><install plugin=\"{{ item }}@latest\" /></jenkins>"
-    status_code: 200,302
+- name: Install plugins
+  jenkins_plugin:
+    name: "{{ item }}"
+    owner: "{{ jenkins_config_owner }}"
+    group: "{{ jenkins_config_group }}"
+    url: "{{ jenkins_url }}:{{ jenkins_port }}"
+    timeout: "{{ jenkins_plugin_timeout }}"
   with_items: "{{ jenkins_plugins }}"
-  when: jenkins_token.status == 200
-
-- name: Install plugins if crumb is disabled
-  uri:
-    url: "{{ jenkins_url }}:{{ jenkins_port }}/pluginManager/installNecessaryPlugins"
-    method: POST
-    headers:
-      Content-Type: "text/xml"
-    body: "<jenkins><install plugin=\"{{ item }}@latest\" /></jenkins>"
-    status_code: 200,302
-  with_items: "{{ jenkins_plugins }}"
-  when: jenkins_token.status == 404
 
 - name: Custom plugins are installed
   copy:
@@ -39,9 +24,3 @@
     mode: 0644
   with_items: "{{ jenkins_custom_plugins }}"
   when: jenkins_custom_plugins is defined
-
-- name: Wait for plugins to finish installing
-  wait_for:
-    path: "{{ jenkins_home }}/plugins/{{ item }}.jpi"
-    timeout: "{{ jenkins_plugin_timeout }}"
-  with_items: "{{ jenkins_plugins }}"


### PR DESCRIPTION
This potentially-controversial PR switches to the native Ansible [`jenkins_plugin`](https://docs.ansible.com/ansible/latest/modules/jenkins_plugin_module.html#jenkins-plugin-module) module for plugin installation. This requires at least Ansible 2.2.

The advantage of using this plugin, other than the reduced complexity of this role, is that it uses the Jenkins REST API to install plugins which seems to be more reliable and faster than calling `pluginManager/installNecessaryPlugins`.

Fixes https://github.com/emmetog/ansible-jenkins/issues/43, ping @emmetog 