### PR TITLE
Add jenkins_home option to jenkins_plugin

### DIFF
--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -9,6 +9,7 @@
 - name: Install plugins
   jenkins_plugin:
     name: "{{ item }}"
+    jenkins_home: "{{ jenkins_home }}"
     owner: "{{ jenkins_config_owner }}"
     group: "{{ jenkins_config_group }}"
     url: "{{ jenkins_url }}:{{ jenkins_port }}"


### PR DESCRIPTION
This fixes an error with "Could not replace file" if the Jenkins user
doesn't have permission to write to /var/lib/jenkins (the default
value of this option).

---

ping @emmetog 