### PR TITLE
Revive wait_for task when installing plugins

### DIFF
--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -44,3 +44,8 @@
     timeout: "{{ jenkins_plugin_timeout }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_auth == "crumb" or jenkins_auth == "none"
+
+- name: Wait for plugins to finish installing
+  wait_for:
+    path: "{{ jenkins_home }}/plugins/{{ item }}.jpi"
+  with_items: "{{ jenkins_plugins }}"


### PR DESCRIPTION
This was erroneously removed (by me) in db5804c. When Jenkins installs
plugins, it first downloads the JPI files and then extracts them when
the service restarts. Jenkins usually reports "success" back to
Ansible right away and then downloads the plugin in the background.

Therefore, we need to wait for the plugin JPI files to finish
appearing on Jenkins before continuing. Otherwise, the next task
(configure-files.yml) will stop the service and can lead to some
plugin installations being prematurely aborted, but the Ansible
deployment believing that everything worked.

---

ping @emmetog 