### PR TITLE
Add missing validate_certs attribute to tasks

### DIFF
--- a/tasks/cancel-quiet-mode.yml
+++ b/tasks/cancel-quiet-mode.yml
@@ -9,6 +9,7 @@
     url_username: "{{ jenkins_api_username }}"
     url_password: "{{ jenkins_api_token }}"
     force_basic_auth: true
+    validate_certs: "{{ jenkins_https_validate_certs }}"
   when: jenkins_auth == "api"
 
 - include_tasks: "get-crumb.yml"
@@ -23,6 +24,7 @@
       Cookie: "{{ jenkins_crumb_cookie }}"
       Jenkins-Crumb: "{{ jenkins_crumb_token }}"
     status_code: 200,302
+    validate_certs: "{{ jenkins_https_validate_certs }}"
   when: jenkins_auth == "crumb"
 
 - name: Cancel quiet mode with no security

--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -42,5 +42,6 @@
     group: "{{ jenkins_config_group }}"
     url: "{{ jenkins_url }}"
     timeout: "{{ jenkins_plugin_timeout }}"
+    validate_certs: "{{ jenkins_https_validate_certs }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_auth == "crumb" or jenkins_auth == "none"

--- a/tasks/set-quiet-mode.yml
+++ b/tasks/set-quiet-mode.yml
@@ -12,6 +12,7 @@
     url_username: "{{ jenkins_api_username }}"
     url_password: "{{ jenkins_api_token }}"
     force_basic_auth: true
+    validate_certs: "{{ jenkins_https_validate_certs }}"
   when: jenkins_auth == "api"
 
 - name: Set quiet mode with crumb
@@ -33,4 +34,5 @@
     headers:
       Content-Type: "text/xml"
     status_code: 200,302
+    validate_certs: "{{ jenkins_https_validate_certs }}"
   when: jenkins_auth == "none"


### PR DESCRIPTION
After https://github.com/emmetog/ansible-jenkins/pull/48 was merged, it caused a merge conflict in https://github.com/emmetog/ansible-jenkins/pull/50. The conflict was resolved, but unfortunately, we should have also added the validate_certs attribute to the new tasks added by that second PR. This commit fixes that.

---

ping @emmetog 