### PR TITLE
Add apt keys as task

### DIFF
--- a/molecule/api-token/Dockerfile.j2
+++ b/molecule/api-token/Dockerfile.j2
@@ -6,8 +6,7 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 648ACFD622F3D138 && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y apt-transport-https aptitude bash ca-certificates sudo python \
         python-apt && \
     apt-get clean

--- a/molecule/bionic/Dockerfile.j2
+++ b/molecule/bionic/Dockerfile.j2
@@ -9,8 +9,6 @@ FROM {{ item.image }}
 RUN apt-get update && \
     apt-get install -y gpg apt-transport-https aptitude bash ca-certificates sudo \
         python python-apt && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 04EE7237B7D453EC && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 648ACFD622F3D138 && \
     apt-get clean
 
 RUN useradd -G sudo molecule

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -8,8 +8,6 @@ FROM {{ item.image }}
 
 RUN \
     if [ $(command -v apt-get) ]; then \
-        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-            --recv-keys 648ACFD622F3D138 && \
         apt-get update && \
         apt-get install -y apt-transport-https aptitude bash ca-certificates sudo \
             python python-apt && \

--- a/molecule/https/Dockerfile.j2
+++ b/molecule/https/Dockerfile.j2
@@ -6,8 +6,7 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 648ACFD622F3D138 && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y apt-transport-https aptitude bash ca-certificates sudo python \
         python-apt && \
     apt-get clean

--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -23,6 +23,16 @@
   apt:
     name: debian-archive-keyring
 
+- name: Add apt keys for debian repositories
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: "{{ key_item }}"
+  with_items:
+    - "04EE7237B7D453EC"
+    - "648ACFD622F3D138"
+  loop_control:
+    loop_var: key_item
+
 - name: Add Debian experimental repository for OpenJDK
   apt_repository:
     repo: deb http://httpredir.debian.org/debian experimental main


### PR DESCRIPTION
I have also tested this change on Xenial/Bionic VMs, so not just
Docker images. This change is also necessary for Bionic support, since
the 04EE7237B7D453EC key is not available there by default.

---

ping @emmetog 