### PR TITLE
Use jenkins_plugin_timeout in wait_for task

### DIFF
--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -49,4 +49,5 @@
 - name: Wait for plugins to finish installing
   wait_for:
     path: "{{ jenkins_home }}/plugins/{{ item }}.jpi"
+    timeout: "{{ jenkins_plugin_timeout }}"
   with_items: "{{ jenkins_plugins }}"


### PR DESCRIPTION
This task is used when waiting for plugins to finish installing from
the Jenkins server, as well as all of their dependencies. Therefore we
need to use jenkins_plugin_timeout both when fetching the plugins (see
the above tasks) and also when waiting for them to finish installing.

---

ping @emmetog