### PR TITLE
Waiting is already done in calling task

### DIFF
--- a/tasks/yum/start.yml
+++ b/tasks/yum/start.yml
@@ -1,12 +1,3 @@
 ---
 - name: "Start Jenkins"
   service: name="jenkins" state="started"
-- name: "Wait for Jenkins to come up"
-  uri:
-    url: "{{ jenkins_url }}"
-    status_code: 200
-    validate_certs: "{{ jenkins_https_validate_certs }}"
-  register: result
-  until: result.status == 200
-  retries: 60
-  delay: 1


### PR DESCRIPTION
There is no waiting in "apt" equivalent and it is already done in `tasks/start.yml`