### PR TITLE
Fix jenkins_after_config_jobs_file config param

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ jenkins_source_dir_jobs: "{{ jenkins_source_dir_configs }}/jobs"
 
 # When defined, include this task file after configuring jobs. This happens
 # at the very end of the role, but before Jenkins is taken out of quiet mode.
-jenkins_after_config_jobs_file: false
+jenkins_after_config_jobs_file: ""
 
 # config.xml template source
 jenkins_source_config_xml: "{{ jenkins_source_dir_configs }}/config.xml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 - include: "configure-jobs.yml"
 
 - include: "{{ jenkins_after_config_jobs_file }}"
-  when: jenkins_after_config_jobs_file
+  when: jenkins_after_config_jobs_file | length > 0
 
 - include: "start.yml"
 


### PR DESCRIPTION
jenkins_after_config_jobs_file should either be undefined or be the path to a file.
Currently, it is either the boolean value "false" or a string representing the file, which makes it impossible to do both "include" and "when" on it.