### PR TITLE
Update new repository signing key

### DIFF
--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -61,15 +61,25 @@
   ignore_errors: true
   changed_when: false
 
-- name: Add Jenkins key
-  apt_key:
-    url: "https://pkg.jenkins.io/debian-stable/jenkins.io.key"
-    state: present
-
-- name: Add Jenkins repository
+- name: Remove old Jenkins repository
   apt_repository:
     repo: 'deb https://pkg.jenkins.io/debian-stable binary/'
-    state: present
+    state: absent
+- name: Remove old Jenkins key
+  apt_key:
+    url: "https://pkg.jenkins.io/debian-stable/jenkins.io.key"
+    state: absent
+
+- name: Add Jenkins repository
+  block:
+    - name: Add Jenkins key
+      get_url:
+        url: "https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key"
+        dest: /usr/share/keyrings/jenkins-keyring.asc
+    - name: Add Jenkins repository
+      apt_repository:
+        repo: 'deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian-stable binary/'
+        state: present
 
 - name: Install Jenkins binary package
   apt:

--- a/tasks/yum/install.yml
+++ b/tasks/yum/install.yml
@@ -31,7 +31,7 @@
     dest: "/etc/yum.repos.d/jenkins.repo"
 
 - name: "Import Jenkins key"
-  command: "rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key"
+  command: "rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key"
   changed_when: false
 
 - name: "Install Jenkins"


### PR DESCRIPTION
https://www.jenkins.io/blog/2023/03/27/repository-signing-keys-changing/

Change will be effective 2023/04/05 for stable (LTS).